### PR TITLE
nonzero! in const expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nonzero_ext"
-version = "0.1.6-dev"
+version = "0.2.0-dev"
 authors = ["Andreas Fuchs <asf@boinkor.net>"]
 license = "Apache-2.0"
 repository = "https://github.com/antifuchs/nonzero_ext"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,9 @@ macro_rules! impl_nonzeroable {
             }
         }
         impl literals::NonZeroLiteral<$nonzeroable_type> {
+            /// Converts the wrapped value to its non-zero equivalent.
+            /// # Safety
+            /// The wrapped value must be non-zero.
             pub const unsafe fn into_nonzero(self) -> $nonzero_type {
                 <$nonzero_type>::new_unchecked(self.0)
             }

--- a/src/literals.rs
+++ b/src/literals.rs
@@ -1,0 +1,9 @@
+//! Handling non-zero literal values.
+
+use super::NonZeroAble;
+
+/// A representation of a non-zero literal. Used by the [`nonzero!`] macro.
+///
+/// This struct has no use outside of this macro (even though it can be constructed by anyone).
+/// It needs to exist to support the use of the [`nonzero!`] macro in const expressions.
+pub struct NonZeroLiteral<T: NonZeroAble>(pub T);

--- a/tests/compile-fail/immoral_math.rs
+++ b/tests/compile-fail/immoral_math.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU32;
+
+fn main() {
+    const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+}

--- a/tests/compile-fail/immoral_math.stderr
+++ b/tests/compile-fail/immoral_math.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/immoral_math.rs:7:42
+  |
+7 |     const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
+  |
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

--- a/tests/run-pass/const_expression.rs
+++ b/tests/run-pass/const_expression.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU32;
+
+fn main() {
+    const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!(42u32);
+}

--- a/tests/run-pass/virtuous_math.rs
+++ b/tests/run-pass/virtuous_math.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU32;
+
+fn main() {
+    const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 * 2 - 21) as u32);
+}


### PR DESCRIPTION
This should fix #5 - by playing some (macro-ified) tricks with a parameterized struct and equally-parameterized impls and a const associated fn, we can actually construct a non-zero value that needs no type annotations (other than on the input value) in a const context!