### PR TITLE
Deprecate the as_* methods, add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * This [CHANGELOG](./CHANGELOG.md) file. I have tried to backfill the major changes since initial release, but there
  are bound to be gaps.
 
+### Changed
+* The `as_nonzero` and `as_nonzero_unchecked` methods on the `NonZeroAble` trait are now named `into_nonzero` and
+ `into_nonzero_unchecked`, respectively. The old methods still exist, but are deprecated.
+
 ## [v0.1.3] - 2019-03-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changes for `nonzero_ext`
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Added
+* Support for `NonZeroI*` types - now `nonzero_ext` should include support for all non-zero integer types that the
+ standard library exports.
+* Support for using `nonzero!` in a [const context](https://doc.rust-lang.org/reference/const_eval.html).
+* This [CHANGELOG](./CHANGELOG.md) file. I have tried to backfill the major changes since initial release, but there
+ are bound to be gaps.
+
+## [v0.1.3] - 2019-03-10
+
+### Added
+* Ability to use the `nonzero_ext` crate in `no_std` mode; to use it without the `std` library, disable default
+ features when pulling this crate into your project.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,6 @@ documentation = "https://docs.rs/nonzero_ext"
 circle-ci = { repository = "antifuchs/nonzero_ext", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
-[package.metadata.release]
-sign-commit = false
-upload-doc = false
-pre-release-commit-message = "Release {{version}} 🎉🎉"
-pro-release-commit-message = "Start next development iteration {{version}}"
-tag-message = "Release {{prefix}}{{version}}"
-dev-version-ext = "dev"
-tag-prefix = "v"
-
 [features]
 default = ["std"]
 std = []

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,11 @@
+sign-commit = false
+pre-release-commit-message = "Release {{version}} 🎉🎉"
+post-release-commit-message = "Start next development iteration {{version}}"
+tag-message = "Release {{prefix}}{{version}}"
+dev-version-ext = "dev"
+tag-prefix = ""
+pre-release-replacements = [
+  {file="CHANGELOG.md", search="Unreleased", replace="{{version}}"},
+  {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
+  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate"},
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ pub trait NonZeroAble {
     /// `NonZeroU8`.
     type NonZero: NonZero;
 
+    //noinspection RsSelfConvention
     /// Converts the integer to its non-zero equivalent.
     ///
     /// # Examples
@@ -174,8 +175,36 @@ pub trait NonZeroAble {
     /// let non0n: NonZeroUsize = n.as_nonzero().expect("should result in a converted value");
     /// assert_eq!(non0n.get(), 20);
     /// ```
-    fn as_nonzero(self) -> Option<Self::NonZero>;
+    #[deprecated(since = "0.2.0", note = "Renamed to `into_nonzero`")]
+    fn as_nonzero(self) -> Option<Self::NonZero>
+    where
+        Self: Sized,
+    {
+        self.into_nonzero()
+    }
 
+    /// Converts the integer to its non-zero equivalent.
+    ///
+    /// # Examples
+    ///
+    /// ### Trying to convert zero
+    /// ``` rust
+    /// # use nonzero_ext::NonZeroAble;
+    /// let n: u16 = 0;
+    /// assert_eq!(n.into_nonzero(), None);
+    /// ```
+    ///
+    /// ### Converting a non-zero value
+    /// ``` rust
+    /// # use nonzero_ext::NonZeroAble;
+    /// # use std::num::NonZeroUsize;
+    /// let n: usize = 20;
+    /// let non0n: NonZeroUsize = n.into_nonzero().expect("should result in a converted value");
+    /// assert_eq!(non0n.get(), 20);
+    /// ```
+    fn into_nonzero(self) -> Option<Self::NonZero>;
+
+    //noinspection RsSelfConvention
     /// Converts the integer to its non-zero equivalent without
     /// checking for zeroness.
     ///
@@ -184,7 +213,23 @@ pub trait NonZeroAble {
     ///
     /// # Safety
     /// The value must not be zero.
-    unsafe fn as_nonzero_unchecked(self) -> Self::NonZero;
+    #[deprecated(since = "0.2.0", note = "Renamed to `into_nonzero_unchecked`")]
+    unsafe fn as_nonzero_unchecked(self) -> Self::NonZero
+    where
+        Self: Sized,
+    {
+        self.into_nonzero_unchecked()
+    }
+
+    /// Converts the integer to its non-zero equivalent without
+    /// checking for zeroness.
+    ///
+    /// This corresponds to the `new_unchecked` function on the
+    /// corresponding NonZero type.
+    ///
+    /// # Safety
+    /// The value must not be zero.    
+    unsafe fn into_nonzero_unchecked(self) -> Self::NonZero;
 }
 
 macro_rules! impl_nonzeroable {
@@ -192,11 +237,11 @@ macro_rules! impl_nonzeroable {
         impl $trait_name for $nonzeroable_type {
             type NonZero = $nonzero_type;
 
-            fn as_nonzero(self) -> Option<$nonzero_type> {
+            fn into_nonzero(self) -> Option<$nonzero_type> {
                 Self::NonZero::new(self)
             }
 
-            unsafe fn as_nonzero_unchecked(self) -> $nonzero_type {
+            unsafe fn into_nonzero_unchecked(self) -> $nonzero_type {
                 Self::NonZero::new_unchecked(self)
             }
         }


### PR DESCRIPTION
Pretty much what it says on the tin: The `as_` methods were misnomers and should have been `into_*` methods. Let's deprecate them and add a changelog.