### PR TITLE
Don't run trybuild tests on stable for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: false, run_cron: false, version: "nightly", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
+# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: false, run_cron: false, version: "nightly", install_commandline: None, commandline: "cargo bench", timeout: None }), clippy: ClippyEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings", timeout: None }), rustfmt: RustfmtEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check", timeout: None }), additional_matrix_entries: {}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "beta"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
 version: "2.1"
 
 executors:
@@ -107,9 +107,9 @@ workflows:
   }
 }
       - test:
-          name: test-nightly
-          version: nightly
-          version_name: nightly
+          name: test-beta
+          version: beta
+          version_name: beta
           filters: {
   "branches": {
     "ignore": [
@@ -153,7 +153,7 @@ workflows:
       - ci_success:
           requires:
           - test-stable
-          - test-nightly
+          - test-beta
           - rustfmt
           - clippy
   scheduled_tests:
@@ -163,9 +163,9 @@ workflows:
           version: stable
           version_name: stable
       - test:
-          name: test-nightly
-          version: nightly
-          version_name: nightly
+          name: test-beta
+          version: beta
+          version_name: beta
     triggers:
       - schedule:
           cron: 0 0 * * 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ allow_failure = false
 
 [dev-dependencies]
 trybuild = "1.0"
-
+rustversion = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ maintenance = { status = "passively-maintained" }
 default = ["std"]
 std = []
 
+[package.metadata.template_ci]
+# We don't care about nightly with its regular/unstable changes to
+# diagnostics, but beta could potentially break compatibility.
+versions = ["stable", "beta"]
+
 [package.metadata.template_ci.clippy]
 allow_failure = false
 

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,3 +1,4 @@
+#[rustversion::stable] // nightly has changed the format of the macro backtrace hint.
 #[test]
 fn compile_test() {
     let t = trybuild::TestCases::new();

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,4 +1,4 @@
-#[rustversion::stable] // nightly has changed the format of the macro backtrace hint.
+#[rustversion::any(stable, beta)] // nightly has changed the format of the macro backtrace hint.
 #[test]
 fn compile_test() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
Nightly has changed the format of the hint, and so all our matchers
are wrong (or rather, they apply only to stable for now).
