### PR TITLE
More nonzeroable types: NonZeroDuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+* Support for defining not-obviously-integral non-zero types, mostly `Duration`.
+
 ## [0.2.0] - 2019-12-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ circle-ci = { repository = "antifuchs/nonzero_ext", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [features]
-default = ["std"]
+default = ["std", "time"]
 std = []
+time = []
 
 [package.metadata.template_ci]
 # We don't care about nightly with its regular/unstable changes to

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://circleci.com/gh/antifuchs/nonzero_ext/tree/master.svg?style=shield)](https://circleci.com/gh/antifuchs/nonzero_ext/tree/master)
+
 # nonzero_ext
 
 ## Traits to represent generic nonzero integer types
@@ -63,6 +65,15 @@ let input_u32: Vec<u32> = vec![0, 20, 5];
 let expected_u32: Vec<NonZeroU32> = vec![nonzero!(20u32), nonzero!(5u32)];
 assert_eq!(expected_u32, only_nonzeros(input_u32));
 ```
+
+### Features selectable at compile time
+
+* `std` (default): If deselected, uses `core` instead of `std`, making
+  this crate compatible with no_std builds.
+
+* `time` (default): If selected (it's on by default), provides a
+  [`time::NonZeroDuration`] type, and allows converting to it from
+  [`Duration`][std::time::Duration] literals.
 
 
 License: Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,15 @@
 //! # }
 //! ```
 //!
+//! ## Features selectable at compile time
+//!
+//! * `std` (default): If deselected, uses `core` instead of `std`, making
+//!   this crate compatible with no_std builds.
+//!
+//! * `time` (default): If selected (it's on by default), provides a
+//!   [`time::NonZeroDuration`] type, and allows converting to it from
+//!   [`Duration`][std::time::Duration] literals.
+//!
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unknown_clippy_lints)]
@@ -96,6 +105,8 @@ mod lib {
 use self::lib::*;
 
 pub mod literals;
+
+#[cfg(feature = "time")]
 pub mod time;
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ pub trait NonZeroAble {
 }
 
 macro_rules! impl_nonzeroable {
-    ($trait_name:ident, $nonzero_type: ty, $nonzeroable_type:ty) => {
+    ($trait_name:ident, $nonzero_type: ty, $nonzeroable_type:ty, $counter:ident, $count:expr) => {
         impl $trait_name for $nonzeroable_type {
             type NonZero = $nonzero_type;
 
@@ -257,10 +257,20 @@ macro_rules! impl_nonzeroable {
             ///
             /// This is assumed to correspond to the "zero-ness" of
             /// the value: Zero set bits means the value is zero.
-            pub const fn count_ones(self) -> usize {
-                <$nonzeroable_type>::count_ones(self.0) as usize
+            pub const fn count_ones($counter) -> usize {
+                $count
             }
         }
+    };
+
+    ($trait_name:ident, $nonzero_type: ty, $nonzeroable_type:ty) => {
+        impl_nonzeroable!(
+            $trait_name,
+            $nonzero_type,
+            $nonzeroable_type,
+            self,
+            <$nonzeroable_type>::count_ones(self.0) as usize
+        );
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,11 +256,8 @@ macro_rules! impl_nonzeroable {
                 <$nonzero_type>::new_unchecked(self.0)
             }
 
-            /// Returns the number of "set" bits in a value.
-            ///
-            /// This is assumed to correspond to the "zero-ness" of
-            /// the value: Zero set bits means the value is zero.
-            pub const fn count_ones($counter) -> usize {
+            /// True if the passed value is non-zero.
+            pub const fn is_nonzero($counter) -> bool {
                 $count
             }
         }
@@ -272,7 +269,7 @@ macro_rules! impl_nonzeroable {
             $nonzero_type,
             $nonzeroable_type,
             self,
-            <$nonzeroable_type>::count_ones(self.0) as usize
+            self.0 != 0
         );
     };
 }
@@ -329,7 +326,7 @@ impl_nonzeroable!(NonZeroAble, NonZeroIsize, isize);
 macro_rules! nonzero {
     ($n:expr) => {{
         #[allow(unknown_lints, eq_op)]
-        let _ = [(); $crate::literals::NonZeroLiteral($n).count_ones() - 1];
+        let _ = [(); ($crate::literals::NonZeroLiteral($n).is_nonzero() as usize) - 1];
         let lit = $crate::literals::NonZeroLiteral($n);
         unsafe { lit.into_nonzero() }
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ macro_rules! impl_nonzeroable {
             }
 
             /// True if the passed value is non-zero.
-            pub const fn is_nonzero($counter) -> bool {
+            pub const fn is_nonzero(&$counter) -> bool {
                 $count
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ pub trait NonZeroAble {
     /// corresponding NonZero type.
     ///
     /// # Safety
-    /// The value must not be zero.    
+    /// The value must not be zero.
     unsafe fn into_nonzero_unchecked(self) -> Self::NonZero;
 }
 
@@ -251,6 +251,14 @@ macro_rules! impl_nonzeroable {
             /// The wrapped value must be non-zero.
             pub const unsafe fn into_nonzero(self) -> $nonzero_type {
                 <$nonzero_type>::new_unchecked(self.0)
+            }
+
+            /// Returns the number of "set" bits in a value.
+            ///
+            /// This is assumed to correspond to the "zero-ness" of
+            /// the value: Zero set bits means the value is zero.
+            pub const fn count_ones(self) -> usize {
+                <$nonzeroable_type>::count_ones(self.0) as usize
             }
         }
     };
@@ -308,7 +316,7 @@ impl_nonzeroable!(NonZeroAble, NonZeroIsize, isize);
 macro_rules! nonzero {
     ($n:expr) => {{
         #[allow(unknown_lints, eq_op)]
-        let _ = [(); ($n.count_ones() as usize) - 1];
+        let _ = [(); $crate::literals::NonZeroLiteral($n).count_ones() - 1];
         let lit = $crate::literals::NonZeroLiteral($n);
         unsafe { lit.into_nonzero() }
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ mod lib {
 use self::lib::*;
 
 pub mod literals;
-pub mod types;
+pub mod time;
 
 #[macro_export]
 macro_rules! impl_nonzeroness {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,9 @@ mod lib {
 use self::lib::*;
 
 pub mod literals;
+pub mod types;
 
+#[macro_export]
 macro_rules! impl_nonzeroness {
     ($trait_name:ident, $nonzero_type:ty, $wrapped:ty) => {
         impl $trait_name for $nonzero_type {
@@ -232,6 +234,7 @@ pub trait NonZeroAble {
     unsafe fn into_nonzero_unchecked(self) -> Self::NonZero;
 }
 
+#[macro_export]
 macro_rules! impl_nonzeroable {
     ($trait_name:ident, $nonzero_type: ty, $nonzeroable_type:ty, $counter:ident, $count:expr) => {
         impl $trait_name for $nonzeroable_type {
@@ -245,7 +248,7 @@ macro_rules! impl_nonzeroable {
                 Self::NonZero::new_unchecked(self)
             }
         }
-        impl literals::NonZeroLiteral<$nonzeroable_type> {
+        impl crate::literals::NonZeroLiteral<$nonzeroable_type> {
             /// Converts the wrapped value to its non-zero equivalent.
             /// # Safety
             /// The wrapped value must be non-zero.

--- a/src/time.rs
+++ b/src/time.rs
@@ -47,7 +47,7 @@ impl_nonzeroable!(
     NonZeroDuration,
     Duration,
     self,
-    self.0.as_nanos().count_ones() as usize
+    self.0.as_nanos() != 0
 );
 
 #[cfg(test)]

--- a/src/time.rs
+++ b/src/time.rs
@@ -19,6 +19,11 @@ impl NonZeroDuration {
         Some(NonZeroDuration(d))
     }
 
+    /// Creates a new NonZeroDuation without checking for non-zeroness
+    ///
+    /// # Safety
+    /// Callers must check that the passed duration is not zero
+    /// nanoseconds long.
     pub const unsafe fn new_unchecked(d: Duration) -> Self {
         NonZeroDuration(d)
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,12 @@
-use crate::{impl_nonzeroable, impl_nonzeroness, NonZero, NonZeroAble};
-use std::time::Duration;
+//! Non-zero time intervals.
 
+use crate::{impl_nonzeroable, impl_nonzeroness, NonZero, NonZeroAble};
+use std::{ops::Add, time::Duration};
+
+/// A non-zero duration.
+///
+/// A `NonZeroDuration` represents a [`Duration`] that can not be the
+/// "zero" duration, that is, zero nanoseconds long.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NonZeroDuration(Duration);
 
@@ -20,6 +26,18 @@ impl NonZeroDuration {
     /// Returns the wrapped Duration.
     pub const fn get(self) -> Duration {
         self.0
+    }
+}
+
+impl Add<Duration> for NonZeroDuration {
+    type Output = NonZeroDuration;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        let res = self.0 + rhs;
+
+        // Duration can not be negative, so an nz duration + a
+        // potentially-zero duration are always a non-zero duration.
+        NonZeroDuration(res)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,58 @@
+use crate::{impl_nonzeroable, impl_nonzeroness, NonZero, NonZeroAble};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NonZeroDuration(Duration);
+
+impl NonZeroDuration {
+    /// Creates a non-zero duration if the passed value is non-zero.
+    pub fn new(d: Duration) -> Option<Self> {
+        if d.as_nanos() == 0 {
+            return None;
+        }
+        Some(NonZeroDuration(d))
+    }
+
+    pub const unsafe fn new_unchecked(d: Duration) -> Self {
+        NonZeroDuration(d)
+    }
+
+    /// Returns the wrapped Duration.
+    pub const fn get(self) -> Duration {
+        self.0
+    }
+}
+
+impl_nonzeroness!(NonZero, NonZeroDuration, Duration);
+impl_nonzeroable!(
+    NonZeroAble,
+    NonZeroDuration,
+    Duration,
+    self,
+    self.0.as_nanos().count_ones() as usize
+);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::nonzero;
+
+    #[test]
+    fn new_checks_for_0() {
+        assert_eq!(NonZeroDuration::new(Duration::from_secs(0)), None);
+    }
+
+    #[test]
+    fn new_returns_nonzeroes() {
+        let d = Duration::from_nanos(823);
+        let nzd = NonZeroDuration::new(d).expect("this is definitely a nonzero duration");
+        assert_eq!(d, nzd.get());
+    }
+
+    #[test]
+    fn macroable() {
+        let d = Duration::from_nanos(823);
+        let nzd = nonzero!(Duration::from_nanos(823));
+        assert_eq!(d, nzd.get());
+    }
+}


### PR DESCRIPTION
This PR introduces a compile-time selected feature `time` that makes this crate export a `time::NonZeroDuration` type. 

It's what it sounds like: a Duration that is guaranteed to not be zero nanos long.