### PR TITLE
Refactor tests & fix for new error format in 1.48

### DIFF
--- a/tests/compile-fail_1.48/immoral_math.rs
+++ b/tests/compile-fail_1.48/immoral_math.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU32;
+
+fn main() {
+    const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+}

--- a/tests/compile-fail_1.48/immoral_math.stderr
+++ b/tests/compile-fail_1.48/immoral_math.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/immoral_math.rs:7:42
+  |
+7 |     const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail_1.48/zero_u8.rs
+++ b/tests/compile-fail_1.48/zero_u8.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU8;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn main() {
+    let _a: NonZeroU8 = nonzero!(0u8);
+}

--- a/tests/compile-fail_1.48/zero_u8.stderr
+++ b/tests/compile-fail_1.48/zero_u8.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/zero_u8.rs:8:25
+  |
+8 |     let _a: NonZeroU8 = nonzero!(0u8);
+  |                         ^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail_1.48/zero_usize.rs
+++ b/tests/compile-fail_1.48/zero_usize.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroUsize;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn main() {
+    let _a: NonZeroUsize = nonzero!(0usize);
+}

--- a/tests/compile-fail_1.48/zero_usize.stderr
+++ b/tests/compile-fail_1.48/zero_usize.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/zero_usize.rs:8:28
+  |
+8 |     let _a: NonZeroUsize = nonzero!(0usize);
+  |                            ^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail_nightly/immoral_math.rs
+++ b/tests/compile-fail_nightly/immoral_math.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU32;
+
+fn main() {
+    const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+}

--- a/tests/compile-fail_nightly/immoral_math.stderr
+++ b/tests/compile-fail_nightly/immoral_math.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/immoral_math.rs:7:42
+  |
+7 |     const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail_nightly/zero_u8.rs
+++ b/tests/compile-fail_nightly/zero_u8.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU8;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn main() {
+    let _a: NonZeroU8 = nonzero!(0u8);
+}

--- a/tests/compile-fail_nightly/zero_u8.stderr
+++ b/tests/compile-fail_nightly/zero_u8.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/zero_u8.rs:8:25
+  |
+8 |     let _a: NonZeroU8 = nonzero!(0u8);
+  |                         ^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail_nightly/zero_usize.rs
+++ b/tests/compile-fail_nightly/zero_usize.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroUsize;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn main() {
+    let _a: NonZeroUsize = nonzero!(0usize);
+}

--- a/tests/compile-fail_nightly/zero_usize.stderr
+++ b/tests/compile-fail_nightly/zero_usize.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/zero_usize.rs:8:28
+  |
+8 |     let _a: NonZeroUsize = nonzero!(0usize);
+  |                            ^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,17 +1,9 @@
-#[rustversion::any(nightly, beta)]
+#[rustversion::any(nightly)]
 #[test]
 fn compile_test_prerelease() {
     let t = trybuild::TestCases::new();
     t.pass("tests/run-pass/*.rs");
-    t.compile_fail("tests/compile-fail_1.46/*.rs");
-}
-
-#[rustversion::any(since(1.46))]
-#[test]
-fn compile_test_since_1_46() {
-    let t = trybuild::TestCases::new();
-    t.pass("tests/run-pass/*.rs");
-    t.compile_fail("tests/compile-fail_1.46/*.rs");
+    t.compile_fail("tests/compile-fail_nightly/*.rs");
 }
 
 #[rustversion::before(1.46)] // nightly+beta has changed the format of the macro backtrace hint.
@@ -20,4 +12,20 @@ fn compile_test_until_1_45() {
     let t = trybuild::TestCases::new();
     t.pass("tests/run-pass/*.rs");
     t.compile_fail("tests/compile-fail_1.45/*.rs");
+}
+
+#[rustversion::all(since(1.46), before(1.48))]
+#[test]
+fn compile_test_since_1_46() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/run-pass/*.rs");
+    t.compile_fail("tests/compile-fail_1.46/*.rs");
+}
+
+#[rustversion::all(since(1.48), not(nightly))]
+#[test]
+fn compile_test_stable_since_1_48() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/run-pass/*.rs");
+    t.compile_fail("tests/compile-fail_1.48/*.rs");
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,3 +1,11 @@
+// TODO: parallel running of trybuild tests doesn't work.
+// Unfortunately, we can't have a single test for successful
+// compilation of various macro invocations. This is prevented by
+// https://github.com/dtolnay/trybuild/issues/58 - trybuild confuses
+// about which test case should be successful or not. Instead, just
+// run the t.pass and t.compile_fail calls in the same test case - we
+// lose parallelism but at least it works.
+
 #[rustversion::any(nightly)]
 #[test]
 fn compile_test_prerelease() {


### PR DESCRIPTION
The beta is failing, that's a good indicator that we should update the test cases.

Also, make sure we don't run the nightly tests as part of the other test cases, and number them correctly with version numbers.

Here, again, I tried and failed to separate the successful (cross-version) test cases from the unsuccessful (version-specific due to various error message formats); but unfortunately, https://github.com/dtolnay/trybuild/issues/58 interferes.