### PR TITLE
Prevent macro trickery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+* The `nonzero!` macro now enforces that its arguments are integer
+  literals. Any other non-zeroable types (even if they implement
+  `nonzero_ext::NonZeroAble`) can not be accepted. This fixes
+  [#17](https://github.com/antifuchs/nonzero_ext/issues/17).
+
+### Contributors
+* [`@joshlf`](https://github.com/joshlf)
+* [`@ComputerDruid`](https://github.com/ComputerDruid)
+
 ## [0.2.0] - 2019-12-23
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,7 @@ macro_rules! impl_nonzeroable {
                 <$nonzero_type>::new_unchecked(self.0)
             }
         }
+        impl literals::sealed::IntegerLiteral for $nonzeroable_type {}
     };
 }
 
@@ -280,6 +281,17 @@ impl_nonzeroable!(NonZeroAble, NonZeroIsize, isize);
 /// known, `nonzero!` requires that you annotate the constant with the
 /// type, so instead of `nonzero!(20)` you must write `nonzero!(20 as
 /// u16)`.
+///
+/// Note that this macro only works with [integer
+/// literals](https://doc.rust-lang.org/reference/tokens.html#integer-literals),
+/// it isn't possible to use the `nonzero!` macro with types other
+/// than the built-in ones.
+///
+/// # Determining the output type
+///
+/// Use a suffix on the input value to determine the output type:
+/// `nonzero!(1_usize)` will return a [`NonZeroUsize`], and
+/// `nonzero!(-1_i32)` will return a [`NonZeroI32`].
 ///
 /// # Const expressions
 ///

--- a/src/literals.rs
+++ b/src/literals.rs
@@ -1,9 +1,15 @@
 //! Handling non-zero literal values.
 
-use super::NonZeroAble;
+pub(crate) mod sealed {
+    use crate::NonZeroAble;
+
+    /// A trait implemented by all known integer literals that can
+    /// appear in source code.
+    pub trait IntegerLiteral: NonZeroAble {}
+}
 
 /// A representation of a non-zero literal. Used by the [`nonzero!`] macro.
 ///
 /// This struct has no use outside of this macro (even though it can be constructed by anyone).
 /// It needs to exist to support the use of the [`nonzero!`] macro in const expressions.
-pub struct NonZeroLiteral<T: NonZeroAble>(pub T);
+pub struct NonZeroLiteral<T: sealed::IntegerLiteral>(pub T);

--- a/tests/compile-fail_1.54/issue-17--adverse-conditions.rs
+++ b/tests/compile-fail_1.54/issue-17--adverse-conditions.rs
@@ -1,0 +1,39 @@
+use nonzero_ext::nonzero;
+use nonzero_ext::{literals::NonZeroLiteral, NonZeroAble};
+use std::num::NonZeroUsize;
+
+struct BadInt(usize);
+impl BadInt {
+    const fn count_ones(&self) -> usize {
+        1 // oops, even zero counts!
+    }
+}
+impl NonZeroAble for BadInt {
+    type NonZero = NonZeroUsize;
+
+    fn into_nonzero(self) -> Option<Self::NonZero> {
+        NonZeroUsize::new(self.0)
+    }
+
+    unsafe fn into_nonzero_unchecked(self) -> Self::NonZero {
+        NonZeroUsize::new_unchecked(self.0)
+    }
+}
+
+// And we can't impl:
+// impl NonZeroLiteral<BadInt> {} // <- also errors.
+trait OtherTrait {
+    /// # Safety
+    /// self must not be NonZeroLiteral(BadInt(0))
+    unsafe fn into_nonzero(self) -> NonZeroUsize;
+}
+
+impl OtherTrait for NonZeroLiteral<BadInt> {
+    unsafe fn into_nonzero(self) -> NonZeroUsize {
+        unsafe { self.0.into_nonzero_unchecked() }
+    }
+}
+
+fn main() {
+    nonzero!(BadInt(0));
+}

--- a/tests/compile-fail_1.54/issue-17--adverse-conditions.stderr
+++ b/tests/compile-fail_1.54/issue-17--adverse-conditions.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `BadInt: literals::sealed::IntegerLiteral` is not satisfied
+  --> $DIR/issue-17--adverse-conditions.rs:31:21
+   |
+31 | impl OtherTrait for NonZeroLiteral<BadInt> {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ the trait `literals::sealed::IntegerLiteral` is not implemented for `BadInt`
+   |
+  ::: $WORKSPACE/src/literals.rs
+   |
+   | pub struct NonZeroLiteral<T: sealed::IntegerLiteral>(pub T);
+   |                              ---------------------- required by this bound in `NonZeroLiteral`
+
+error[E0277]: the trait bound `BadInt: literals::sealed::IntegerLiteral` is not satisfied
+  --> $DIR/issue-17--adverse-conditions.rs:32:28
+   |
+32 |     unsafe fn into_nonzero(self) -> NonZeroUsize {
+   |                            ^^^^ the trait `literals::sealed::IntegerLiteral` is not implemented for `BadInt`
+   |
+  ::: $WORKSPACE/src/literals.rs
+   |
+   | pub struct NonZeroLiteral<T: sealed::IntegerLiteral>(pub T);
+   |                              ---------------------- required by this bound in `NonZeroLiteral`


### PR DESCRIPTION
This PR fixes #17 by ensuring the `nonzero!` macro input types must be built-in integer literals. This doesn't affect the usage of `NonZero` and `NonZeroAble`, only the usage of our code shorthand.