### PR TITLE
New compile-fail tests for 1.56

### DIFF
--- a/tests/compile-fail_1.56/immoral_math.rs
+++ b/tests/compile-fail_1.56/immoral_math.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU32;
+
+fn main() {
+    const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+}

--- a/tests/compile-fail_1.56/immoral_math.stderr
+++ b/tests/compile-fail_1.56/immoral_math.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/immoral_math.rs:7:42
+  |
+7 |     const _MY_NON_ZERO_U32: NonZeroU32 = nonzero!((42 / 2 - 21) as u32);
+  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in the macro `nonzero` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail_1.56/issue-17--adverse-conditions.rs
+++ b/tests/compile-fail_1.56/issue-17--adverse-conditions.rs
@@ -1,0 +1,39 @@
+use nonzero_ext::nonzero;
+use nonzero_ext::{literals::NonZeroLiteral, NonZeroAble};
+use std::num::NonZeroUsize;
+
+struct BadInt(usize);
+impl BadInt {
+    const fn count_ones(&self) -> usize {
+        1 // oops, even zero counts!
+    }
+}
+impl NonZeroAble for BadInt {
+    type NonZero = NonZeroUsize;
+
+    fn into_nonzero(self) -> Option<Self::NonZero> {
+        NonZeroUsize::new(self.0)
+    }
+
+    unsafe fn into_nonzero_unchecked(self) -> Self::NonZero {
+        NonZeroUsize::new_unchecked(self.0)
+    }
+}
+
+// And we can't impl:
+// impl NonZeroLiteral<BadInt> {} // <- also errors.
+trait OtherTrait {
+    /// # Safety
+    /// self must not be NonZeroLiteral(BadInt(0))
+    unsafe fn into_nonzero(self) -> NonZeroUsize;
+}
+
+impl OtherTrait for NonZeroLiteral<BadInt> {
+    unsafe fn into_nonzero(self) -> NonZeroUsize {
+        unsafe { self.0.into_nonzero_unchecked() }
+    }
+}
+
+fn main() {
+    nonzero!(BadInt(0));
+}

--- a/tests/compile-fail_1.56/issue-17--adverse-conditions.stderr
+++ b/tests/compile-fail_1.56/issue-17--adverse-conditions.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `BadInt: literals::sealed::IntegerLiteral` is not satisfied
+  --> $DIR/issue-17--adverse-conditions.rs:31:21
+   |
+31 | impl OtherTrait for NonZeroLiteral<BadInt> {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ the trait `literals::sealed::IntegerLiteral` is not implemented for `BadInt`
+   |
+note: required by a bound in `NonZeroLiteral`
+  --> $DIR/literals.rs:15:30
+   |
+15 | pub struct NonZeroLiteral<T: sealed::IntegerLiteral>(pub T);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NonZeroLiteral`
+
+error[E0277]: the trait bound `BadInt: literals::sealed::IntegerLiteral` is not satisfied
+  --> $DIR/issue-17--adverse-conditions.rs:32:28
+   |
+32 |     unsafe fn into_nonzero(self) -> NonZeroUsize {
+   |                            ^^^^ the trait `literals::sealed::IntegerLiteral` is not implemented for `BadInt`
+   |
+note: required by a bound in `NonZeroLiteral`
+  --> $DIR/literals.rs:15:30
+   |
+15 | pub struct NonZeroLiteral<T: sealed::IntegerLiteral>(pub T);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NonZeroLiteral`

--- a/tests/compile-fail_1.56/zero_u8.rs
+++ b/tests/compile-fail_1.56/zero_u8.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroU8;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn main() {
+    let _a: NonZeroU8 = nonzero!(0u8);
+}

--- a/tests/compile-fail_1.56/zero_u8.stderr
+++ b/tests/compile-fail_1.56/zero_u8.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/zero_u8.rs:8:25
+  |
+8 |     let _a: NonZeroU8 = nonzero!(0u8);
+  |                         ^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in the macro `nonzero` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail_1.56/zero_usize.rs
+++ b/tests/compile-fail_1.56/zero_usize.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate nonzero_ext;
+
+use std::num::NonZeroUsize;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn main() {
+    let _a: NonZeroUsize = nonzero!(0usize);
+}

--- a/tests/compile-fail_1.56/zero_usize.stderr
+++ b/tests/compile-fail_1.56/zero_usize.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/zero_usize.rs:8:28
+  |
+8 |     let _a: NonZeroUsize = nonzero!(0usize);
+  |                            ^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in the macro `nonzero` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -32,9 +32,16 @@ fn compile_fail_test_stable_since_1_48() {
     t.compile_fail("tests/compile-fail_1.48/*.rs");
 }
 
-#[rustversion::all(since(1.54.0), not(nightly))]
+#[rustversion::all(since(1.54.0), before(1.56.0))]
 #[test]
 fn compile_fail_test_since_1_54() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile-fail_1.54/*.rs");
+}
+
+#[rustversion::all(since(1.56.0), not(nightly))]
+#[test]
+fn compile_fail_test_since_1_54() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail_1.56/*.rs");
 }


### PR DESCRIPTION
Error diagnostics changed again, let's match them.